### PR TITLE
Use reserved value instead of NULL for thruster commands

### DIFF
--- a/project2/project2.ino
+++ b/project2/project2.ino
@@ -73,11 +73,9 @@ void setCycleMode(CycleMode mode) {
     if (mode == CycleModeMajor) {
         // TODO
         // set console display to info mode
-        thrusterSubsystemData.thrusterCommand = &thrusterCommand;
     } else {
         // TODO
         // set console display to annunciation mode
-        thrusterSubsystemData.thrusterCommand = NULL;
     }
 }
 

--- a/project2/thrusterSubsystem.h
+++ b/project2/thrusterSubsystem.h
@@ -1,6 +1,17 @@
 #ifndef _THRUSTER_SUBSYSTEM_H_
 #define _THRUSTER_SUBSYSTEM_H_
 
+#include <stdint.h>
+
+/*
+ * This is a special value of thrusterCommand that represents the absence
+ * of a new command.
+ *
+ * This value was chosen because it would be unreasonable to use all thrusters
+ * at the same time.
+ */
+#define THRUSTER_CMD_NONE 0xFFFF
+
 
 typedef struct {
     unsigned int *thrusterCommand;
@@ -9,5 +20,22 @@ typedef struct {
 
 
 void thrusterSubsystem(void *thrusterSubsystemData);
+
+/*
+ * Create a thruster command.
+ *
+ * inputs:
+ *  useLeft: true iff the left thruster should be used
+ *  useRight: true iff the right thruster should be used
+ *  useUp: true iff the up thruster should be used
+ *  useDown: true iff the up thruster should be used
+ *  magnitude: the magnitude of the thrust from 0 to 15
+ *  duration: the duration of the command in seconds
+ *
+ * outputs: the formatted thrust command (as in thrusterSubsystem.ino)
+ */
+uint16_t createThrusterCommand(bool useLeft, bool useRight, bool useUp,
+                               bool useDown, uint8_t magnitude,
+                               uint8_t duration);
 
 #endif  /* _THRUSTER_SUBSYSTEM_H_ */


### PR DESCRIPTION
This makes it possible for the satellite comms system to indicate there is no new command.

I also added a `createThrusterCommand` function which might help the comms system and debugging in general.