### PR TITLE
Refactor commands/telemetry to be more abstract

### DIFF
--- a/cosmos/config/targets/SATELLITE/cmd_tlm/cmd.txt
+++ b/cosmos/config/targets/SATELLITE/cmd_tlm/cmd.txt
@@ -1,16 +1,16 @@
 COMMAND SATELLITE INC_PANEL_SPEED LITTLE_ENDIAN "Increase panel speed"
   # This must always be the first entry in any command packet
-  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 0, tid: 6, opc: 0 } %>
+  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 0, id: 0 } %>
 
 
 COMMAND SATELLITE DEC_PANEL_SPEED LITTLE_ENDIAN "Decrease panel speed"
   # This must always be the first entry in any command packet
-  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 0, tid: 6, opc: 1 } %>
+  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 0, id: 1 } %>
 
 
 COMMAND SATELLITE THRUSTER LITTLE_ENDIAN "Send thruster command"
   # This must always be the first entry in any command packet
-  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 2, tid: 7, opc: 0 } %>
+  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 2, id: 2 } %>
   
   APPEND_PARAMETER DURATION 8 UINT 0 255 10 "Duration"
     UNITS Seconds s
@@ -22,10 +22,10 @@ COMMAND SATELLITE THRUSTER LITTLE_ENDIAN "Send thruster command"
 
 COMMAND SATELLITE VEHICLE LITTLE_ENDIAN "Send vehicle command"
   # This must always be the first entry in any command packet
-  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 1, tid: 8, opc: 0 } %>
+  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 1, id: 3 } %>
 
   APPEND_PARAMETER COMMAND 8 STRING "A" "Command"
 
 COMMAND SATELLITE ACK_TEMP LITTLE_ENDIAN "Acknowledge temp. alarm"
   # This must always be the first entry in any command packet
-  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 0, tid: 9, opc: 0 } %>
+  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 0, id: 4 } %>

--- a/cosmos/config/targets/SATELLITE/cmd_tlm/tlm.txt
+++ b/cosmos/config/targets/SATELLITE/cmd_tlm/tlm.txt
@@ -1,10 +1,10 @@
-TELEMETRY SATELLITE META LITTLE_ENDIAN "Telemetry Status"
+TELEMETRY SATELLITE TLM_STATUS LITTLE_ENDIAN "Telemetry Status"
   <%= render "../../SYSTEM/cmd_tlm/_shared_tlm_header.txt", locals: { id: 0 } %>
   
   APPEND_ITEM NTLM 8 UINT "Number of telemetry senders"
 
 
-TELEMETRY SATELLITE META LITTLE_ENDIAN "Command Status"
+TELEMETRY SATELLITE CMD_STATUS LITTLE_ENDIAN "Command Status"
   <%= render "../../SYSTEM/cmd_tlm/_shared_tlm_header.txt", locals: { id: 9 } %>
   
   APPEND_ITEM NERRS 8 UINT "Number of errors"

--- a/cosmos/config/targets/SATELLITE/cmd_tlm/tlm.txt
+++ b/cosmos/config/targets/SATELLITE/cmd_tlm/tlm.txt
@@ -1,9 +1,14 @@
 TELEMETRY SATELLITE META LITTLE_ENDIAN "Telemetry Status"
   <%= render "../../SYSTEM/cmd_tlm/_shared_tlm_header.txt", locals: { id: 0 } %>
   
+  APPEND_ITEM NTLM 8 UINT "Number of telemetry senders"
+
+
+TELEMETRY SATELLITE META LITTLE_ENDIAN "Command Status"
+  <%= render "../../SYSTEM/cmd_tlm/_shared_tlm_header.txt", locals: { id: 9 } %>
+  
   APPEND_ITEM NERRS 8 UINT "Number of errors"
   APPEND_ITEM NCMD 8 UINT "Number of command handlers"
-  APPEND_ITEM NTLM 8 UINT "Number of telemetry senders"
 
 
 TELEMETRY SATELLITE POWER LITTLE_ENDIAN "Power Subsystem"
@@ -70,7 +75,8 @@ TELEMETRY SATELLITE TIMES BIG_ENDIAN "Execution times"
   <%= render "_exec_time.txt", locals: { tname: "ALARM" } %>
   <%= render "_exec_time.txt", locals: { tname: "IMAGE" } %>
   <%= render "_exec_time.txt", locals: { tname: "DISTANCE" } %>
-  APPEND_ITEM PAD 128 UINT
+  <%= render "_exec_time.txt", locals: { tname: "COMMAND" } %>
+  APPEND_ITEM PAD 96 UINT
 
 TELEMETRY SATELLITE IMAGE LITTLE_ENDIAN "Image capture freq."
   <%= render "../../SYSTEM/cmd_tlm/_shared_tlm_header.txt", locals: { id: 6 } %>

--- a/cosmos/config/targets/SYSTEM/cmd_tlm/_shared_cmd_header.txt
+++ b/cosmos/config/targets/SYSTEM/cmd_tlm/_shared_cmd_header.txt
@@ -1,3 +1,2 @@
   APPEND_PARAMETER LENGTH 8 UINT <%= length %> <%= length %> <%= length %>
-  APPEND_ID_PARAMETER ENTITYID 8 UINT <%= tid %> <%= tid %> <%= tid %> "Task ID"
-  APPEND_ID_PARAMETER OPCODE 8 UINT <%= opc %> <%= opc %> <%= opc %> "Opcode passed to the entity command handler."
+  APPEND_ID_PARAMETER CMDID 8 UINT <%= id %> <%= id %> <%= id %> "ID passed to the entity command handler."

--- a/satellite/binarySatelliteComs.cpp
+++ b/satellite/binarySatelliteComs.cpp
@@ -3,12 +3,12 @@
 #include "sharedVariables.h"
 #include <Arduino.h>
 
-#define MAX_TLM_SENDERS      16
+#define MAX_TLM_SENDERS      32
 #define TLM_SYNC_PATTERN     0xFC
 
 // Telemetry IDs unique to the entire satellite
 // Keep this in sync with COSMOS
-#define TLMID_META 0
+#define TLMID_TLM_STATUS 0
 
 
 typedef struct {
@@ -47,7 +47,7 @@ void bcInit() {
     );
 
     memset(tlmSenders, 0, sizeof(tlmSenders));
-    bcRegisterTlmSender(BUS_GROUND, TLMID_META, sizeof(metaPacket),
+    bcRegisterTlmSender(BUS_GROUND, TLMID_TLM_STATUS, sizeof(metaPacket),
             &metaPacket);
 }
 
@@ -65,7 +65,7 @@ void binarySatelliteComs(void *bcData) {
 
     // update meta packet
     metaPacket.numTlmSenders = numTlmSenders;
-    bcSend(TLMID_META);
+    bcSend(TLMID_TLM_STATUS);
 }
 
 void bcRegisterTlmSender(serial_bus *bus, uint8_t tlmId, uint8_t length,
@@ -87,9 +87,11 @@ void bcSend(uint8_t tlmId) {
     for (uint8_t i = 0; i < numTlmSenders; i++) {
         if (tlmSenders[i].tlmId == tlmId) {
             tlmSenders[i].ready = true;
-            break;
+            return;
         }
     }
+    Serial.print("unknown tlm id! ");
+    Serial.println(tlmId);
 }
 
 void sendTelemetryPacket(serial_bus *bus, uint8_t tlmId, uint8_t *data,

--- a/satellite/binarySatelliteComs.cpp
+++ b/satellite/binarySatelliteComs.cpp
@@ -6,9 +6,13 @@
 #define MAX_TLM_SENDERS      16
 #define TLM_SYNC_PATTERN     0xFC
 
+// Telemetry IDs unique to the entire satellite
+// Keep this in sync with COSMOS
+#define TLMID_META 0
+
 
 typedef struct {
-    TlmId tlmId;
+    uint8_t tlmId;
     uint8_t length;
     uint8_t *data;
     bool ready;
@@ -19,7 +23,7 @@ TLM_PACKET {
 } MetaPacket;
 
 
-void sendTelemetryPacket(TlmId tlmId, uint8_t *data, uint8_t size);
+void sendTelemetryPacket(uint8_t tlmId, uint8_t *data, uint8_t size);
 
 
 TCB bcTCB;
@@ -61,7 +65,7 @@ void binarySatelliteComs(void *bcData) {
     bcSend(TLMID_META);
 }
 
-void bcRegisterTlmSender(TlmId tlmId, uint8_t length, void *data) {
+void bcRegisterTlmSender(uint8_t tlmId, uint8_t length, void *data) {
     if (numTlmSenders >= MAX_TLM_SENDERS) {
         Serial.println(F("ERROR! Too many telementry senders!"));
         return;
@@ -74,7 +78,7 @@ void bcRegisterTlmSender(TlmId tlmId, uint8_t length, void *data) {
     };
 }
 
-void bcSend(TlmId tlmId) {
+void bcSend(uint8_t tlmId) {
     for (uint8_t i = 0; i < numTlmSenders; i++) {
         if (tlmSenders[i].tlmId == tlmId) {
             tlmSenders[i].ready = true;
@@ -83,7 +87,7 @@ void bcSend(TlmId tlmId) {
     }
 }
 
-void sendTelemetryPacket(TlmId tlmId, uint8_t *data, uint8_t size) {
+void sendTelemetryPacket(uint8_t tlmId, uint8_t *data, uint8_t size) {
     // write the header (sync byte, full length, and ID)
     Serial.write(TLM_SYNC_PATTERN);
     Serial.write(size + 3); // add 3 for these header bytes

--- a/satellite/binarySatelliteComs.h
+++ b/satellite/binarySatelliteComs.h
@@ -2,9 +2,15 @@
 
 #include <stdint.h>
 #include "schedule.h"
+#include <Arduino.h>
 
 #define TLM_PACKET typedef struct __attribute__((__packed__))
 
+#define BUS_GROUND  (&Serial)
+#define BUS_VEHICLE (&Serial1)
+
+
+typedef HardwareSerial serial_bus;
 
 typedef struct { 
 } BCData;
@@ -19,11 +25,13 @@ void binarySatelliteComs(void *bcData);
 
 /**
  * inputs:
+ *  bus:    The serial bus to send the packet on
  *  tlmId:  The unique telemetry ID
  *  length: The length of the telemetry, not counting the header
  *  data:   The telemtry to send. Must be a static location
  */
-void bcRegisterTlmSender(uint8_t tlmId, uint8_t length, void *data);
+void bcRegisterTlmSender(serial_bus *bus, uint8_t tlmId, uint8_t length,
+        void *data);
 
 /**
  * Indicate that a registered telemetry packet is ready to send.

--- a/satellite/binarySatelliteComs.h
+++ b/satellite/binarySatelliteComs.h
@@ -6,25 +6,6 @@
 #define TLM_PACKET typedef struct __attribute__((__packed__))
 
 
-/*
- * Telemetry IDs used to identify telemetry packets
- *
- * These must be unique across the entire satellite.
- * Range 0 through 255.
- */
-typedef enum {
-    TLMID_META =        0,
-    TLMID_POWER =       1,
-    TLMID_SOLAR_PANEL = 2,
-    TLMID_THRUSTER =    3,
-    TLMID_TIMES =       5,
-    TLMID_IMAGE =       6,
-    TLMID_DISTANCE =    7,
-    TLMID_VEHICLE =     8,
-    TLMID_COMMAND =     9,
-} TlmId;
-
-
 typedef struct { 
 } BCData;
 
@@ -42,7 +23,7 @@ void binarySatelliteComs(void *bcData);
  *  length: The length of the telemetry, not counting the header
  *  data:   The telemtry to send. Must be a static location
  */
-void bcRegisterTlmSender(TlmId tlmId, uint8_t length, void *data);
+void bcRegisterTlmSender(uint8_t tlmId, uint8_t length, void *data);
 
 /**
  * Indicate that a registered telemetry packet is ready to send.
@@ -50,5 +31,5 @@ void bcRegisterTlmSender(TlmId tlmId, uint8_t length, void *data);
  * inputs:
  *  tlmId: The unique telemetry ID
  */
-void bcSend(TlmId tlmId);
+void bcSend(uint8_t tlmId);
 

--- a/satellite/binarySatelliteComs.h
+++ b/satellite/binarySatelliteComs.h
@@ -21,13 +21,11 @@ typedef enum {
     TLMID_IMAGE =       6,
     TLMID_DISTANCE =    7,
     TLMID_VEHICLE =     8,
+    TLMID_COMMAND =     9,
 } TlmId;
 
-// returns true if the command was handled
-typedef bool (*cmd_handler_fn)(uint8_t, uint8_t*);
 
-typedef struct {
-    uint8_t *numErrors;
+typedef struct { 
 } BCData;
 
 
@@ -54,4 +52,3 @@ void bcRegisterTlmSender(TlmId tlmId, uint8_t length, void *data);
  */
 void bcSend(TlmId tlmId);
 
-void bcRegisterCmdHandler(TaskId taskId, cmd_handler_fn handler);

--- a/satellite/command.cpp
+++ b/satellite/command.cpp
@@ -1,0 +1,115 @@
+#include "command.h"
+#include "schedule.h"
+#include "binarySatelliteComs.h"
+#include "sharedVariables.h"
+#include <Arduino.h>
+
+#define MAX_COMMAND_HANDLERS 16
+#define CMD_SYNC_PATTERN     0xFC
+#define SERIAL_TIMEOUT_MS    100
+
+
+typedef struct {
+    TaskId taskId;
+    cmd_callback_fn handle;
+} CommandHandler;
+
+TLM_PACKET {
+    uint8_t numErrors;
+    uint8_t numCmdHandlers;
+} CmdTlmPacket;
+
+
+// reads an incoming command from Serial and dispatches it to a command handler
+void processCommand(CmdData *data);
+
+// returns true if it found the sync byte
+bool sync();
+
+
+CommandHandler commandHandlers[MAX_COMMAND_HANDLERS];
+uint8_t numCommandHandlers = 0;
+
+TCB cmdTCB;
+CmdData cmdData = {
+    &numCmdErrors
+};
+
+CmdTlmPacket cmdTlmPacket;
+
+
+void cmdInit() {
+    tcbInit(
+        &cmdTCB,
+        &cmdData,
+        cmdUpdate,
+        TASKID_COMMAND,
+        1
+    );
+
+    Serial.setTimeout(SERIAL_TIMEOUT_MS);
+    numCmdErrors = 0;
+    memset(commandHandlers, 0, sizeof(commandHandlers));
+}
+
+void cmdUpdate(void *cmdData) {
+    CmdData *data = (CmdData *) cmdData;
+
+    // process commands
+    while (sync()) {
+        processCommand(data);
+    }
+
+    // send metadata telementry
+    cmdTlmPacket.numErrors = *data->numErrors;
+    bcSend(TLMID_COMMAND);
+}
+
+void cmdRegisterCallback(TaskId taskId, cmd_callback_fn callback) {
+    if (numCommandHandlers >= MAX_COMMAND_HANDLERS) {
+        Serial.println(F("ERROR! Too many command handlers!"));
+        return;
+    }
+    commandHandlers[numCommandHandlers++] = {
+        taskId,
+        callback
+    };
+}
+
+bool sync() {
+    while (Serial.available()) {
+        if (Serial.read() == CMD_SYNC_PATTERN) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void processCommand(CmdData *cmdData) {
+    // read the header
+    uint8_t length;
+    uint8_t taskId;
+    uint8_t opcode;
+    Serial.readBytes(&length, 1);
+    Serial.readBytes(&taskId, 1);
+    Serial.readBytes(&opcode, 1);
+
+    // read the body of the command
+    uint8_t data[256];
+    Serial.readBytes(data, length);
+
+    // dispatch to different entities
+    bool handled = false;
+    for (uint8_t i = 0; i < numCommandHandlers; i++) {
+        CommandHandler *h = &commandHandlers[i];
+        if (taskId == h->taskId) {
+            handled = h->handle(opcode, data);
+            break;
+        }
+    }
+
+    // report unhandled commands
+    if (!handled) {
+        cmdData->numErrors++;
+    }
+}

--- a/satellite/command.cpp
+++ b/satellite/command.cpp
@@ -10,7 +10,7 @@
 
 // Telemetry IDs unique to the entire satellite
 // Keep this in sync with COSMOS
-#define TLMID_COMMAND 9
+#define TLMID_CMD_STATUS 9
 
 
 typedef struct {
@@ -58,6 +58,8 @@ void cmdInit() {
 
     numCmdErrors = 0;
     memset(commandHandlers, 0, sizeof(commandHandlers));
+    bcRegisterTlmSender(BUS_GROUND, TLMID_CMD_STATUS, sizeof(cmdTlmPacket),
+        &cmdTlmPacket);
 }
 
 void cmdUpdate(void *cmdData) {
@@ -73,7 +75,7 @@ void cmdUpdate(void *cmdData) {
 
     // send metadata telementry
     cmdTlmPacket.numErrors = *data->numErrors;
-    bcSend(TLMID_COMMAND);
+    bcSend(TLMID_CMD_STATUS);
 }
 
 void cmdRegisterCallback(uint8_t cmdId, cmd_callback_fn callback) {

--- a/satellite/command.cpp
+++ b/satellite/command.cpp
@@ -10,7 +10,7 @@
 
 
 typedef struct {
-    TaskId taskId;
+    CmdId cmdId;
     cmd_callback_fn handle;
 } CommandHandler;
 
@@ -65,13 +65,13 @@ void cmdUpdate(void *cmdData) {
     bcSend(TLMID_COMMAND);
 }
 
-void cmdRegisterCallback(TaskId taskId, cmd_callback_fn callback) {
+void cmdRegisterCallback(CmdId cmdId, cmd_callback_fn callback) {
     if (numCommandHandlers >= MAX_COMMAND_HANDLERS) {
         Serial.println(F("ERROR! Too many command handlers!"));
         return;
     }
     commandHandlers[numCommandHandlers++] = {
-        taskId,
+        cmdId,
         callback
     };
 }
@@ -88,11 +88,9 @@ bool sync() {
 void processCommand(CmdData *cmdData) {
     // read the header
     uint8_t length;
-    uint8_t taskId;
-    uint8_t opcode;
+    uint8_t cmdId;
     Serial.readBytes(&length, 1);
-    Serial.readBytes(&taskId, 1);
-    Serial.readBytes(&opcode, 1);
+    Serial.readBytes(&cmdId, 1);
 
     // read the body of the command
     uint8_t data[256];
@@ -102,8 +100,8 @@ void processCommand(CmdData *cmdData) {
     bool handled = false;
     for (uint8_t i = 0; i < numCommandHandlers; i++) {
         CommandHandler *h = &commandHandlers[i];
-        if (taskId == h->taskId) {
-            handled = h->handle(opcode, data);
+        if (cmdId == h->cmdId) {
+            handled = h->handle(data);
             break;
         }
     }

--- a/satellite/command.cpp
+++ b/satellite/command.cpp
@@ -8,9 +8,13 @@
 #define CMD_SYNC_PATTERN     0xFC
 #define SERIAL_TIMEOUT_MS    100
 
+// Telemetry IDs unique to the entire satellite
+// Keep this in sync with COSMOS
+#define TLMID_COMMAND 9
+
 
 typedef struct {
-    CmdId cmdId;
+    uint8_t cmdId;
     cmd_callback_fn handle;
 } CommandHandler;
 
@@ -65,7 +69,7 @@ void cmdUpdate(void *cmdData) {
     bcSend(TLMID_COMMAND);
 }
 
-void cmdRegisterCallback(CmdId cmdId, cmd_callback_fn callback) {
+void cmdRegisterCallback(uint8_t cmdId, cmd_callback_fn callback) {
     if (numCommandHandlers >= MAX_COMMAND_HANDLERS) {
         Serial.println(F("ERROR! Too many command handlers!"));
         return;

--- a/satellite/command.h
+++ b/satellite/command.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <stdint.h>
+#include "schedule.h"
+
+
+// returns true if the command was handled
+typedef bool (*cmd_callback_fn)(uint8_t, uint8_t*);
+
+typedef struct {
+    uint8_t *numErrors;
+} CmdData;
+
+
+extern TCB cmdTCB;
+
+
+void cmdInit();
+
+void cmdUpdate(void *cmdData);
+
+void cmdRegisterCallback(TaskId taskId, cmd_callback_fn callback);

--- a/satellite/command.h
+++ b/satellite/command.h
@@ -4,15 +4,6 @@
 #include "schedule.h"
 
 
-typedef enum {
-    CMDID_INC_PANEL_SPEED = 0,
-    CMDID_DEC_PANEL_SPEED = 1,
-    CMDID_THRUSTER =        2,
-    CMDID_VEHICLE =         3,
-    CMDID_ACK_TEMP =        4
-} CmdId;
-
-
 // returns true if the command was handled
 typedef bool (*cmd_callback_fn)(uint8_t*);
 
@@ -28,4 +19,4 @@ void cmdInit();
 
 void cmdUpdate(void *cmdData);
 
-void cmdRegisterCallback(CmdId cmdId, cmd_callback_fn callback);
+void cmdRegisterCallback(uint8_t cmdId, cmd_callback_fn callback);

--- a/satellite/command.h
+++ b/satellite/command.h
@@ -4,8 +4,17 @@
 #include "schedule.h"
 
 
+typedef enum {
+    CMDID_INC_PANEL_SPEED = 0,
+    CMDID_DEC_PANEL_SPEED = 1,
+    CMDID_THRUSTER =        2,
+    CMDID_VEHICLE =         3,
+    CMDID_ACK_TEMP =        4
+} CmdId;
+
+
 // returns true if the command was handled
-typedef bool (*cmd_callback_fn)(uint8_t, uint8_t*);
+typedef bool (*cmd_callback_fn)(uint8_t*);
 
 typedef struct {
     uint8_t *numErrors;
@@ -19,4 +28,4 @@ void cmdInit();
 
 void cmdUpdate(void *cmdData);
 
-void cmdRegisterCallback(TaskId taskId, cmd_callback_fn callback);
+void cmdRegisterCallback(CmdId cmdId, cmd_callback_fn callback);

--- a/satellite/imageCapture.cpp
+++ b/satellite/imageCapture.cpp
@@ -76,7 +76,8 @@ void imageCaptureInit() {
     // initialize the timer interrupt
     imageCaptureTimerInit();
 
-    bcRegisterTlmSender(TLMID_IMAGE, sizeof(tlmPacket), &tlmPacket);
+    bcRegisterTlmSender(BUS_GROUND, TLMID_IMAGE, sizeof(tlmPacket),
+            &tlmPacket);
 }
 
 void imageCaptureTimerInit() {

--- a/satellite/imageCapture.cpp
+++ b/satellite/imageCapture.cpp
@@ -13,6 +13,10 @@
 // maximum milli-volts for an analogRead
 #define IMAGE_CAPTURE_MAX_MVOLTS 5000.0
 
+// Telemetry IDs unique to the entire satellite
+// Keep this in sync with COSMOS
+#define TLMID_IMAGE 6
+
 
 TLM_PACKET {
     uint16_t frequency;

--- a/satellite/powerSubsystem.cpp
+++ b/satellite/powerSubsystem.cpp
@@ -8,6 +8,11 @@
 #include "solarPanel.h"
 #include "udools.h"
 
+// Telemetry IDs unique to the entire satellite
+// Keep this in sync with COSMOS
+#define TLMID_POWER 1
+
+
 TLM_PACKET {
     uint32_t batteryLevel;
     uint16_t temperature;

--- a/satellite/powerSubsystem.cpp
+++ b/satellite/powerSubsystem.cpp
@@ -155,7 +155,8 @@ void powerSubsystemInit() {
     *powerSubsystemData.batteryTempHigh = false;
 
     // register telemerty
-    bcRegisterTlmSender(TLMID_POWER, sizeof(tlmPacket), &tlmPacket);
+    bcRegisterTlmSender(BUS_GROUND, TLMID_POWER, sizeof(tlmPacket),
+            &tlmPacket);
 }
 
 void measurementExternalInterruptISR() {

--- a/satellite/satellite.ino
+++ b/satellite/satellite.ino
@@ -13,6 +13,7 @@
 #include "imageCapture.h"
 #include "schedule.h"
 #include "transportDistance.h"
+#include "command.h"
 #include "tft.h"
 
 #include <AUnit.h>  // Test framework
@@ -34,7 +35,7 @@ bool driveMotorSpeedInc;
 bool driveMotorSpeedDec;
 char vehicleCommand;
 char vehicleResponse;
-uint8_t numTlmErrors;
+uint8_t numCmdErrors;
 bool batteryTempHigh;
 
 bool temperatureAlarmAcked;
@@ -76,6 +77,7 @@ void setup() {
     transportDistanceInit();
     vehicleCommsInit();
     warningAlarmInit();
+    cmdInit();
 
     powerSubsystemTCB.priority = 1;
     taskQueueInsert(&powerSubsystemTCB);
@@ -85,6 +87,9 @@ void setup() {
 
     imageCaptureTCB.priority = 1;
     taskQueueInsert(&imageCaptureTCB);
+
+    cmdTCB.priority = 2;
+    taskQueueInsert(&cmdTCB);
 
     vehicleCommsTCB.priority = 4;
     taskQueueInsert(&vehicleCommsTCB);

--- a/satellite/schedule.cpp
+++ b/satellite/schedule.cpp
@@ -3,6 +3,10 @@
 #include "binarySatelliteComs.h"
 #include <Arduino.h>
 
+// Telemetry IDs unique to the entire satellite
+// Keep this in sync with COSMOS
+#define TLMID_TIMES 5
+
 
 TLM_PACKET {
     // the execution time of each task in microseconds

--- a/satellite/schedule.cpp
+++ b/satellite/schedule.cpp
@@ -37,7 +37,8 @@ TimePacket timePacket;
 void scheduleInit() {
     missionElapsedTime = millis();
 
-    bcRegisterTlmSender(TLMID_TIMES, sizeof(timePacket), &timePacket);
+    bcRegisterTlmSender(BUS_GROUND, TLMID_TIMES, sizeof(timePacket),
+            &timePacket);
 }
 
 void schedule() {

--- a/satellite/schedule.h
+++ b/satellite/schedule.h
@@ -27,6 +27,7 @@ typedef enum {
     TASKID_ALARM =    9,
     TASKID_IMAGE =    10,
     TASKID_DISTANCE = 11,
+    TASKID_COMMAND =  12,
 } TaskId;
 
 typedef void (*tcb_task_fn)(void *data);

--- a/satellite/sharedVariables.h
+++ b/satellite/sharedVariables.h
@@ -35,7 +35,7 @@ extern bool driveMotorSpeedInc;
 extern bool driveMotorSpeedDec;
 extern char vehicleCommand;
 extern char vehicleResponse;
-extern uint8_t numTlmErrors;
+extern uint8_t numCmdErrors;
 extern bool batteryTempHigh;
 
 extern bool temperatureAlarmAcked;

--- a/satellite/solarPanel.cpp
+++ b/satellite/solarPanel.cpp
@@ -3,6 +3,7 @@
 #include "schedule.h"
 #include "sharedVariables.h"
 #include "binarySatelliteComs.h"
+#include "command.h"
 #include <Arduino.h>
 
 // the max value of the solar panel speed
@@ -63,7 +64,7 @@ void solarPanelControlInit() {
         solarPanelStop, RISING);
 
     bcRegisterTlmSender(TLMID_SOLAR_PANEL, sizeof(tlmPacket), &tlmPacket);
-    bcRegisterCmdHandler(TASKID_PANEL, solarPanelProcessCommand);
+    cmdRegisterCallback(TASKID_PANEL, solarPanelProcessCommand);
 }
 
 void solarPanelControl(void *solarPanelControlData) {

--- a/satellite/solarPanel.cpp
+++ b/satellite/solarPanel.cpp
@@ -18,9 +18,15 @@
 // the value added to the stopped duty cycle to achieve max speed
 #define SOLAR_PANEL_DUTY_CYCLE_RANGE   100
 
-// opcodes for commands over Serial
-#define SOLAR_PANEL_OPCODE_INC 0
-#define SOLAR_PANEL_OPCODE_DEC 1
+// command IDs for commands over Serial
+// these must be unique to the entire satellite
+// keep this in sync with COSMOS
+#define CMDID_INC_PANEL_SPEED 0
+#define CMDID_DEC_PANEL_SPEED 1
+
+// Telemetry IDs unique to the entire satellite
+// Keep this in sync with COSMOS
+#define TLMID_SOLAR_PANEL 2
 
 
 TLM_PACKET {

--- a/satellite/solarPanel.cpp
+++ b/satellite/solarPanel.cpp
@@ -70,7 +70,8 @@ void solarPanelControlInit() {
     attachInterrupt(digitalPinToInterrupt(PIN_SOLAR_PANEL_STOPPED),
         solarPanelStop, RISING);
 
-    bcRegisterTlmSender(TLMID_SOLAR_PANEL, sizeof(tlmPacket), &tlmPacket);
+    bcRegisterTlmSender(BUS_GROUND, TLMID_SOLAR_PANEL, sizeof(tlmPacket),
+            &tlmPacket);
     cmdRegisterCallback(CMDID_INC_PANEL_SPEED, handleIncCommand);
     cmdRegisterCallback(CMDID_INC_PANEL_SPEED, handleDecCommand);
 }

--- a/satellite/solarPanel.cpp
+++ b/satellite/solarPanel.cpp
@@ -30,7 +30,8 @@ TLM_PACKET {
 
 void solarPanelStop();
 
-bool solarPanelProcessCommand(uint8_t opcode, uint8_t *data);
+bool handleIncCommand(uint8_t *data);
+bool handleDecCommand(uint8_t *data);
 
 
 TCB solarPanelControlTCB;
@@ -64,7 +65,8 @@ void solarPanelControlInit() {
         solarPanelStop, RISING);
 
     bcRegisterTlmSender(TLMID_SOLAR_PANEL, sizeof(tlmPacket), &tlmPacket);
-    cmdRegisterCallback(TASKID_PANEL, solarPanelProcessCommand);
+    cmdRegisterCallback(CMDID_INC_PANEL_SPEED, handleIncCommand);
+    cmdRegisterCallback(CMDID_INC_PANEL_SPEED, handleDecCommand);
 }
 
 void solarPanelControl(void *solarPanelControlData) {
@@ -126,17 +128,14 @@ void solarPanelControl(void *solarPanelControlData) {
     bcSend(TLMID_SOLAR_PANEL);
 }
 
-bool solarPanelProcessCommand(uint8_t opcode, uint8_t *data) {
-    switch(opcode) {
-        case SOLAR_PANEL_OPCODE_INC:
-            driveMotorSpeedInc = true;
-            return true;
-        case SOLAR_PANEL_OPCODE_DEC:
-            driveMotorSpeedDec = true;
-            return true;
-        default:
-            return false;
-    }
+bool handleIncCommand(uint8_t *data) {
+    driveMotorSpeedInc = true;
+    return true;
+}
+
+bool handleDecCommand(uint8_t *data) {
+    driveMotorSpeedDec = true;
+    return true;
 }
 
 void solarPanelStop() {

--- a/satellite/thrusterSubsystem.cpp
+++ b/satellite/thrusterSubsystem.cpp
@@ -62,7 +62,8 @@ void thrusterSubsystemInit() {
     );
 
     cmdRegisterCallback(CMDID_THRUSTER, thrusterSubsystemProcessCommand);
-    bcRegisterTlmSender(TLMID_THRUSTER, sizeof(tlmPacket), &tlmPacket);
+    bcRegisterTlmSender(BUS_GROUND, TLMID_THRUSTER, sizeof(tlmPacket),
+            &tlmPacket);
 }
 
 /******************************************************************************

--- a/satellite/thrusterSubsystem.cpp
+++ b/satellite/thrusterSubsystem.cpp
@@ -15,7 +15,14 @@
  */
 #define MSEC_PER_FUEL_UNIT_PER_MAG_LSB 210240000
 
-#define CMDID_THRUSTER 0
+// command IDs for commands over Serial
+// these must be unique to the entire satellite
+// keep this in sync with COSMOS
+#define CMDID_THRUSTER 2
+
+// Telemetry IDs unique to the entire satellite
+// Keep this in sync with COSMOS
+#define TLMID_THRUSTER 3
 
 
 TLM_PACKET {

--- a/satellite/thrusterSubsystem.cpp
+++ b/satellite/thrusterSubsystem.cpp
@@ -28,7 +28,7 @@ TLM_PACKET {
  * This is a command handler to be registered with binary satellite coms.
  * It processing a command destined for the thruster subsystem.
  */
-bool thrusterSubsystemProcessCommand(uint8_t opcode, uint8_t *data);
+bool thrusterSubsystemProcessCommand(uint8_t *data);
 
 
 TCB thrusterSubsystemTCB;
@@ -54,7 +54,7 @@ void thrusterSubsystemInit() {
         1
     );
 
-    cmdRegisterCallback(TASKID_THRUST, thrusterSubsystemProcessCommand);
+    cmdRegisterCallback(CMDID_THRUSTER, thrusterSubsystemProcessCommand);
     bcRegisterTlmSender(TLMID_THRUSTER, sizeof(tlmPacket), &tlmPacket);
 }
 
@@ -205,10 +205,7 @@ uint16_t createThrusterCommand(bool useLeft, bool useRight, bool useUp,
     return cmd;
 }
 
-bool thrusterSubsystemProcessCommand(uint8_t opcode, uint8_t *data) {
-    if (opcode != CMDID_THRUSTER) {
-        return false;
-    }
+bool thrusterSubsystemProcessCommand(uint8_t *data) {
     // TODO this seems to be broken somehow
     thrusterCommand = *((uint16_t *) data);
     return true;

--- a/satellite/thrusterSubsystem.cpp
+++ b/satellite/thrusterSubsystem.cpp
@@ -3,6 +3,7 @@
 #include "predefinedMacros.h"
 #include "sharedVariables.h"
 #include "binarySatelliteComs.h"
+#include "command.h"
 #include <stdint.h>
 
 /*
@@ -53,7 +54,7 @@ void thrusterSubsystemInit() {
         1
     );
 
-    bcRegisterCmdHandler(TASKID_THRUST, thrusterSubsystemProcessCommand);
+    cmdRegisterCallback(TASKID_THRUST, thrusterSubsystemProcessCommand);
     bcRegisterTlmSender(TLMID_THRUSTER, sizeof(tlmPacket), &tlmPacket);
 }
 

--- a/satellite/transportDistance.cpp
+++ b/satellite/transportDistance.cpp
@@ -16,6 +16,10 @@
 #define MAX_DISTANCE 2000
 #define MEASURE_DIFF 0.10
 
+// Telemetry IDs unique to the entire satellite
+// Keep this in sync with COSMOS
+#define TLMID_DISTANCE 7
+
 
 TLM_PACKET {
     float distance;

--- a/satellite/transportDistance.cpp
+++ b/satellite/transportDistance.cpp
@@ -74,7 +74,8 @@ void transportDistanceInit() {
         TASKID_DISTANCE,
         3
     );
-    bcRegisterTlmSender(TLMID_DISTANCE, sizeof(tlmPacket), &tlmPacket);
+    bcRegisterTlmSender(BUS_GROUND, TLMID_DISTANCE, sizeof(tlmPacket),
+            &tlmPacket);
 }
 
 void transportDistance(void *transportDistanceData) {

--- a/satellite/vehicleComms.cpp
+++ b/satellite/vehicleComms.cpp
@@ -4,6 +4,7 @@
 #include "schedule.h"
 #include "sharedVariables.h"
 #include "binarySatelliteComs.h"
+#include "command.h"
 #include "transportDistance.h"
 
 
@@ -34,7 +35,7 @@ void vehicleCommsInit() {
         1
     );
     bcRegisterTlmSender(TLMID_VEHICLE, sizeof(tlmPacket), &tlmPacket);
-    bcRegisterCmdHandler(TASKID_VEHCOMS, handleCommand);
+    cmdRegisterCallback(TASKID_VEHCOMS, handleCommand);
 }
 
 /******************************************************************************

--- a/satellite/vehicleComms.cpp
+++ b/satellite/vehicleComms.cpp
@@ -7,6 +7,15 @@
 #include "command.h"
 #include "transportDistance.h"
 
+// command IDs for commands over Serial
+// these must be unique to the entire satellite
+// keep this in sync with COSMOS
+#define CMDID_VEHICLE 3
+
+// Telemetry IDs unique to the entire satellite
+// Keep this in sync with COSMOS
+#define TLMID_VEHICLE 8
+
 
 TLM_PACKET {
     char response;

--- a/satellite/vehicleComms.cpp
+++ b/satellite/vehicleComms.cpp
@@ -13,7 +13,7 @@ TLM_PACKET {
 } VehiclePacket;
 
 
-bool handleCommand(uint8_t opcode, uint8_t *data);
+bool handleCommand(uint8_t *data);
 
 
 TCB vehicleCommsTCB;
@@ -35,7 +35,7 @@ void vehicleCommsInit() {
         1
     );
     bcRegisterTlmSender(TLMID_VEHICLE, sizeof(tlmPacket), &tlmPacket);
-    cmdRegisterCallback(TASKID_VEHCOMS, handleCommand);
+    cmdRegisterCallback(CMDID_VEHICLE, handleCommand);
 }
 
 /******************************************************************************
@@ -103,6 +103,7 @@ void vehicleComms(void *vehicleCommsData) {
 
 }
 
-bool handleCommand(uint8_t opcode, uint8_t *data) {
+bool handleCommand(uint8_t *data) {
     vehicleCommand = data[0];
+    return true;
 }

--- a/satellite/vehicleComms.cpp
+++ b/satellite/vehicleComms.cpp
@@ -43,7 +43,8 @@ void vehicleCommsInit() {
         TASKID_VEHCOMS,
         1
     );
-    bcRegisterTlmSender(TLMID_VEHICLE, sizeof(tlmPacket), &tlmPacket);
+    bcRegisterTlmSender(BUS_GROUND, TLMID_VEHICLE, sizeof(tlmPacket),
+            &tlmPacket);
     cmdRegisterCallback(CMDID_VEHICLE, handleCommand);
 }
 

--- a/satellite/warningAlarm.cpp
+++ b/satellite/warningAlarm.cpp
@@ -17,6 +17,11 @@
 
 #define ACK_PIN         35
 
+// command IDs for commands over Serial
+// these must be unique to the entire satellite
+// keep this in sync with COSMOS
+#define CMDID_ACK_TEMP 4
+
 
 static bool handleCommand(uint8_t *data);
 

--- a/satellite/warningAlarm.cpp
+++ b/satellite/warningAlarm.cpp
@@ -18,7 +18,7 @@
 #define ACK_PIN         35
 
 
-static bool handleCommand(uint8_t opcode, uint8_t *data);
+static bool handleCommand(uint8_t *data);
 
 
 TCB warningAlarmTCB;
@@ -46,7 +46,7 @@ void warningAlarmInit() {
     pinMode(ACK_PIN, INPUT);
 
     // optionally acknowledge temperature through serial
-    cmdRegisterCallback(TASKID_ALARM, handleCommand);
+    cmdRegisterCallback(CMDID_ACK_TEMP, handleCommand);
 }
 
 void warningAlarm(void *warningAlarmData) {
@@ -164,7 +164,7 @@ void warningAlarm(void *warningAlarmData) {
 }
 
 // handle command from serial
-static bool handleCommand(uint8_t opcode, uint8_t *data) {
+static bool handleCommand(uint8_t *data) {
     temperatureAlarmAcked = true;
     return true;
 }

--- a/satellite/warningAlarm.cpp
+++ b/satellite/warningAlarm.cpp
@@ -4,6 +4,7 @@
 #include "schedule.h"
 #include "sharedVariables.h"
 #include "binarySatelliteComs.h"
+#include "command.h"
 #include "tft.h"
 
 #define HALF_FUEL       50
@@ -45,7 +46,7 @@ void warningAlarmInit() {
     pinMode(ACK_PIN, INPUT);
 
     // optionally acknowledge temperature through serial
-    bcRegisterCmdHandler(TASKID_ALARM, handleCommand);
+    cmdRegisterCallback(TASKID_ALARM, handleCommand);
 }
 
 void warningAlarm(void *warningAlarmData) {


### PR DESCRIPTION
This lets us use `binarySatelliteComs.h` and `command.h` for both ground station and satellite I/O. `command.h` processes commands from both serial buses. For `binarySatelliteComs.h`, we can use `bcRegisterTlmSender(BUS_GROUND, ...)` for telemetry sent to the ground station, and `bcRegisterTlmSender(BUS_VEHICLE, ...)` for commands sent to the vehicle.

The names here can be kind of confusing. For example, the TLMID that the satellite uses to send commands to the vehicle will be a CMDID from the vehicle's perspective.