### PR TITLE
Fix length rx/tx asymmetry

### DIFF
--- a/cosmos/config/targets/SATELLITE/cmd_tlm/cmd.txt
+++ b/cosmos/config/targets/SATELLITE/cmd_tlm/cmd.txt
@@ -1,16 +1,16 @@
 COMMAND SATELLITE INC_PANEL_SPEED LITTLE_ENDIAN "Increase panel speed"
   # This must always be the first entry in any command packet
-  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 0, id: 0 } %>
+  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 3, id: 0 } %>
 
 
 COMMAND SATELLITE DEC_PANEL_SPEED LITTLE_ENDIAN "Decrease panel speed"
   # This must always be the first entry in any command packet
-  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 0, id: 1 } %>
+  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 3, id: 1 } %>
 
 
 COMMAND SATELLITE THRUSTER LITTLE_ENDIAN "Send thruster command"
   # This must always be the first entry in any command packet
-  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 2, id: 2 } %>
+  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 5, id: 2 } %>
   
   APPEND_PARAMETER MAG 4 UINT 0 15 15 "Magnitude"
   APPEND_PARAMETER LEFT 1 UINT 0 1 0 "Left thruster"
@@ -22,10 +22,10 @@ COMMAND SATELLITE THRUSTER LITTLE_ENDIAN "Send thruster command"
 
 COMMAND SATELLITE VEHICLE LITTLE_ENDIAN "Send vehicle command"
   # This must always be the first entry in any command packet
-  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 1, id: 3 } %>
+  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 4, id: 3 } %>
 
   APPEND_PARAMETER COMMAND 8 STRING "A" "Command"
 
 COMMAND SATELLITE ACK_TEMP LITTLE_ENDIAN "Acknowledge temp. alarm"
   # This must always be the first entry in any command packet
-  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 0, id: 4 } %>
+  <%= render "../../SYSTEM/cmd_tlm/_shared_cmd_header.txt", locals: { length: 3, id: 4 } %>

--- a/cosmos/config/targets/SATELLITE/cmd_tlm/tlm.txt
+++ b/cosmos/config/targets/SATELLITE/cmd_tlm/tlm.txt
@@ -40,6 +40,8 @@ TELEMETRY SATELLITE SOLAR_PANEL LITTLE_ENDIAN "Solar panel"
 TELEMETRY SATELLITE THRUSTER LITTLE_ENDIAN "Thruster Subsystem"
   <%= render "../../SYSTEM/cmd_tlm/_shared_tlm_header.txt", locals: { id: 3 } %>
 
+  APPEND_ITEM DURATION 8 UINT "Duration"
+    UNITS Seconds s
   APPEND_ITEM MAG 4 UINT "Magnitude"
   APPEND_ITEM LEFT 1 UINT "Left thruster"
     STATE ON  1
@@ -53,8 +55,6 @@ TELEMETRY SATELLITE THRUSTER LITTLE_ENDIAN "Thruster Subsystem"
   APPEND_ITEM DOWN 1 UINT "Down thruster"
     STATE ON  1
     STATE OFF 0
-  APPEND_ITEM DURATION 8 UINT "Duration"
-    UNITS Seconds s
   APPEND_ITEM FUEL 16 UINT "Fuel level"
     LIMITS DEFAULT 1 ENABLED 10 50 101 101
 

--- a/satellite/comsReceive.cpp
+++ b/satellite/comsReceive.cpp
@@ -108,7 +108,7 @@ void processCommand(serial_bus *bus, CmdData *cmdData) {
 
     // read the body of the command
     uint8_t data[256];
-    bus->readBytes(data, length);
+    bus->readBytes(data, length - 3); // subtract 3 for the header bytes
 
     // dispatch to different entities
     bool handled = false;


### PR DESCRIPTION
Now the length field in all Serial packets represent the length of the entire packet -- not just the payload.